### PR TITLE
Allow rerun with tests failing using data test method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: setup dotnet
         uses: actions/setup-dotnet@v3
@@ -37,3 +40,25 @@ jobs:
         with:
           path-to-lcov: test/dotnet-test-rerun.IntegrationTests/coverage/lcov.info
           flag-name: IntegrationTests
+
+      - name: bump & tag
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          cd .. && git reset --hard && git clean -df && cd src
+          dotnet versionize --pre-release alpha
+
+      - name: git push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref }}
+          tags: true
+
+      - name: pack
+        run: dotnet pack --configuration Release --no-build --no-restore
+
+      - name: push
+        run: dotnet nuget push nupkg/dotnet-test-rerun.*.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   build_and_test:
-    name: 🛠️ Build & 🧪 Test
+    name: 🛠️ Build, 🧪 Test, 📦 Pack & 🚚 Push alpha
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -20,6 +20,15 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+
+      - name: detect changes on src folder
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            src:
+              - 'src/**'
 
       - name: setup dotnet
         uses: actions/setup-dotnet@v3
@@ -41,24 +50,29 @@ jobs:
           path-to-lcov: test/dotnet-test-rerun.IntegrationTests/coverage/lcov.info
           flag-name: IntegrationTests
 
-      - name: bump & tag
+        # run only if some file in 'src' folder was changed
+      - if: steps.changes.outputs.src == 'true'
+        name: bump & tag
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           cd .. && git reset --hard && git clean -df && cd src
           dotnet versionize --pre-release alpha
 
-      - name: git push
+      - if: steps.changes.outputs.src == 'true'
+        name: git push
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}
           tags: true
 
-      - name: pack
+      - if: steps.changes.outputs.src == 'true'
+        name: pack
         run: dotnet pack --configuration Release --no-build --no-restore
 
-      - name: push
+      - if: steps.changes.outputs.src == 'true'
+        name: push
         run: dotnet nuget push nupkg/dotnet-test-rerun.*.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY --skip-duplicate
         env:
           NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}

--- a/src/Analyzers/TestResultsAnalyzer.cs
+++ b/src/Analyzers/TestResultsAnalyzer.cs
@@ -20,7 +20,8 @@ public class TestResultsAnalyzer : ITestResultsAnalyzer
 
         var tests = trx.Results.UnitTestResults
             .Where(t => t.Outcome.Equals(outcome, StringComparison.InvariantCultureIgnoreCase))
-            .Select(t => $"FullyQualifiedName~{t.TestName}")
+            .Select(t => $"FullyQualifiedName~{(t.TestName.IndexOf("(") > 0 ? t.TestName.Substring(0, t.TestName.IndexOf("(")) : t.TestName).TrimEnd()}")
+            .Distinct()
             .ToList();
 
         if (tests.Count == 0)

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [versionize](https://github.com/versionize/versionize) for commit guidelines.
+
+<a name="1.2.2-alpha.0"></a>
+## [1.2.2-alpha.0](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.2.2-alpha.0) (2023-6-27)
+
+### Bug Fixes
+
+* add additional tests for several tests inside data method failing ([0aa5ca2](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/0aa5ca2aafad864667bbf0012aa4dca80caee651))
+

--- a/src/RerunCommand/RerunCommand.cs
+++ b/src/RerunCommand/RerunCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.CommandLine;
 using System.IO.Abstractions;
+using System.Text.RegularExpressions;
 using dotnet.test.rerun.Analyzers;
 using dotnet.test.rerun.DotNetTestRunner;
 using dotnet.test.rerun.Enums;

--- a/src/dotnet-test-rerun.csproj
+++ b/src/dotnet-test-rerun.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression> GPL-3.0-or-later</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>1.2.1</Version>
+    <Version>1.2.2-alpha.0</Version>
     <PackageProjectUrl>https://github.com/joaoopereira/dotnet-test-rerun</PackageProjectUrl>
     <Description>wrapper of dotnet test command that automatic rerun failed tests</Description>
     <RepositoryUrl>https://github.com/joaoopereira/dotnet-test-rerun</RepositoryUrl>

--- a/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
@@ -47,6 +47,21 @@ public class DotNetTestRerunTests
     }
 
     [Fact]
+    public async Task DotnetTestRerun_FailingMSTest_Fails()
+    {
+        // Act
+        var output = await RunDotNetTestRerunAndCollectOutputMessage("FailingMSTestExample");
+
+        // Assert
+        output.Should().NotContain("Passed!");
+        output.Should().Contain("Failed!", Exactly.Times(4));
+        output.Should().Contain("Rerun filter: FullyQualifiedName~SimpleNumberFailCompare",
+            Exactly.Thrice());        
+        output.Should().Contain("Failed:     2, Passed:     6",
+            Exactly.Once());
+    }
+
+    [Fact]
     public async Task DotnetTestRerun_RunNUnitExample_Success()
     {
         // Act
@@ -69,6 +84,21 @@ public class DotNetTestRerunTests
         output.Should().Contain("Rerun filter: FullyQualifiedName~FailingXUnitExample.SimpleTest.SimpleStringCompare",
             Exactly.Thrice());        
         output.Should().Contain("Passed:     4",
+            Exactly.Once());
+    }
+
+    [Fact]
+    public async Task DotnetTestRerun_FailingMultipleXUnit_Fails()
+    {
+        // Act
+        var output = await RunDotNetTestRerunAndCollectOutputMessage("FailingMultipleXUnitExample");
+
+        // Assert
+        output.Should().NotContain("Passed!");
+        output.Should().Contain("Failed!", Exactly.Times(4));
+        output.Should().Contain("Rerun filter: FullyQualifiedName~FailingXUnitExample.SimpleTest.SimpleFailedNumberCompare",
+            Exactly.Thrice());        
+        output.Should().Contain("Failed:     2, Passed:     5",
             Exactly.Once());
     }
 

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMSTestExample/FailingMSTestExample.csproj
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMSTestExample/FailingMSTestExample.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+        <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    </ItemGroup>
+
+</Project>

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMSTestExample/SimpleTest.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMSTestExample/SimpleTest.cs
@@ -1,0 +1,25 @@
+namespace MSTestExample;
+
+[TestClass]
+public class UnitTest1
+{
+    [DataTestMethod]
+    [DataRow(1, 1)]
+    [DataRow(2, 2)]
+    [DataRow(3, 3)]
+    [DataRow(4, 4)]
+    public void SimpleNumberCompare(int number, int expectedNumber)
+    {
+        Assert.AreEqual(expectedNumber, number);
+    }
+    
+    [DataTestMethod]
+    [DataRow(1, 1)]
+    [DataRow(2, 3)]
+    [DataRow(3, 4)]
+    [DataRow(4, 4)]
+    public void SimpleNumberFailCompare(int number, int expectedNumber)
+    {
+        Assert.AreEqual(expectedNumber, number);
+    }
+}

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMSTestExample/Usings.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMSTestExample/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMultipleXUnitExample/FailingMultipleXUnitExample.csproj
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMultipleXUnitExample/FailingMultipleXUnitExample.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+
+        <OutputType>Library</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMultipleXUnitExample/SimpleTest.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMultipleXUnitExample/SimpleTest.cs
@@ -1,0 +1,23 @@
+namespace FailingXUnitExample;
+
+public class SimpleTest
+{
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 3)]
+    [InlineData(4, 4)]
+    public void SimpleNumberCompare(int number, int expectedNumber)
+    {
+        Assert.Equal(expectedNumber, number);
+    }
+    
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 3)]
+    [InlineData(4, 6)]
+    public void SimpleFailedNumberCompare(int number, int expectedNumber)
+    {
+        Assert.Equal(number, expectedNumber);
+    }
+}

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMultipleXUnitExample/Usings.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/FailingMultipleXUnitExample/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/dotnet-test-rerun.UnitTests/Analyzers/TestResultsAnalyzerTests.cs
+++ b/test/dotnet-test-rerun.UnitTests/Analyzers/TestResultsAnalyzerTests.cs
@@ -52,10 +52,7 @@ public class TestResultsAnalyzerTests
         var result = TestResultsAnalyzer.GetFailedTestsFilter(trxFile!);
 
         //Assert
-        result.Should().Be("FullyQualifiedName~XUnitExample.UnitTest1.SimpleNumberCompare(number: 1) | " +
-                           "FullyQualifiedName~XUnitExample.UnitTest1.SimpleStringCompare | " +
-                           "FullyQualifiedName~XUnitExample.UnitTest1.SimpleNumberCompare(number: 3) | " +
-                           "FullyQualifiedName~XUnitExample.UnitTest1.SimpleNumberCompare(number: 4)");
+        result.Should().Be("FullyQualifiedName~XUnitExample.UnitTest1.SimpleNumberCompare | FullyQualifiedName~XUnitExample.UnitTest1.SimpleStringCompare");
     }
     
     [Fact]
@@ -81,7 +78,7 @@ public class TestResultsAnalyzerTests
         var result = TestResultsAnalyzer.GetFailedTestsFilter(trxFile!);
 
         //Assert
-        result.Should().Be("FullyQualifiedName~SimpleStringCompare()");
+        result.Should().Be("FullyQualifiedName~SimpleStringCompare");
     }
     
     [Fact]
@@ -94,10 +91,7 @@ public class TestResultsAnalyzerTests
         var result = TestResultsAnalyzer.GetFailedTestsFilter(trxFile!);
 
         //Assert
-        result.Should().Be("FullyQualifiedName~SimpleStringCompare() | " +
-                           "FullyQualifiedName~SimpleNumberCompare(1,2) | " +
-                           "FullyQualifiedName~SimpleNumberCompare(3,2) | " +
-                           "FullyQualifiedName~SimpleNumberCompare(4,2)");
+        result.Should().Be("FullyQualifiedName~SimpleStringCompare | FullyQualifiedName~SimpleNumberCompare");
     }
     
     [Fact]
@@ -136,10 +130,7 @@ public class TestResultsAnalyzerTests
         var result = TestResultsAnalyzer.GetFailedTestsFilter(trxFile!);
 
         //Assert
-        result.Should().Be("FullyQualifiedName~SimpleNumberCompare (1,2) | " +
-                           "FullyQualifiedName~SimpleStringCompare | " +
-                           "FullyQualifiedName~SimpleNumberCompare (3,2) | " +
-                           "FullyQualifiedName~SimpleNumberCompare (4,2)");
+        result.Should().Be("FullyQualifiedName~SimpleNumberCompare | FullyQualifiedName~SimpleStringCompare");
     }
     
     [Fact]


### PR DESCRIPTION
#42 

![image](https://github.com/joaoopereira/dotnet-test-rerun/assets/93729031/1961d0ed-149d-4add-971f-6ebe3453ba44)

As of now the approach will be to run the full test again if one of the DataTestMethods fail