### PR TITLE
fix: return failure return code to process when tests fail #45

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [versionize](https://github.com/versionize/versionize) for commit guidelines.
 
+<a name="1.3.0-alpha.1"></a>
+## [1.3.0-alpha.1](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.3.0-alpha.1) (2023-7-2)
+
+### Bug Fixes
+
+* add additional tests for several tests inside data method failing ([f1d9864](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/f1d9864d15d429a4b7cb2ab6a3b70057508104ab))
+* add additional tests for several tests inside data method failing ([433b9e4](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/433b9e4f3bcaadd3a62d08e4c9bc76561533f206))
+* return failure return code to process when tests fail #45 ([f9f15d1](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/f9f15d1858a449a9a682fd03920bca6e5eca7a5b))
+
 <a name="1.3.0-alpha.0"></a>
 ## [1.3.0-alpha.0](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.3.0-alpha.0) (2023-7-2)
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [versionize](https://github.com/versionize/versionize) for commit guidelines.
 
+<a name="1.2.2-alpha.1"></a>
+## [1.2.2-alpha.1](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.2.2-alpha.1) (2023-7-1)
+
+### Bug Fixes
+
+* add additional tests for several tests inside data method failing ([5550b2d](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/5550b2d8885f7b1fcdeef08d2b25f7e9c2d9c193))
+* return failure return code to process when tests fail #45 ([016e841](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/016e841d3d32b9360fa4601da18617f42100fbfc))
+
 <a name="1.2.2-alpha.0"></a>
 ## [1.2.2-alpha.0](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.2.2-alpha.0) (2023-6-27)
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [versionize](https://github.com/versionize/versionize) for commit guidelines.
 
+<a name="1.3.0-alpha.2"></a>
+## [1.3.0-alpha.2](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.3.0-alpha.2) (2023-7-2)
+
+### Bug Fixes
+
+* solve warnings and issue in tests ([e0441f3](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/e0441f301cfc862dce7c32b84e12aef46dd0e65a))
+
 <a name="1.3.0-alpha.1"></a>
 ## [1.3.0-alpha.1](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.3.0-alpha.1) (2023-7-2)
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [versionize](https://github.com/versionize/versionize) for commit guidelines.
 
+<a name="1.3.0-alpha.0"></a>
+## [1.3.0-alpha.0](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.3.0-alpha.0) (2023-7-2)
+
+### Features
+
+* add option to delete report files ([8aa07d8](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/8aa07d882f2686bcd1ee00da8dc487041edaa4ad))
+
+### Bug Fixes
+
+* return failure return code to process when tests fail #45 ([3666dc0](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/3666dc0a47a27cf681c8c5189cea7b5e720511e7))
+
 <a name="1.2.2-alpha.1"></a>
 ## [1.2.2-alpha.1](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.2.2-alpha.1) (2023-7-1)
 

--- a/src/DotNetTestRunner/DotNetTestRunner.cs
+++ b/src/DotNetTestRunner/DotNetTestRunner.cs
@@ -58,9 +58,9 @@ namespace dotnet.test.rerun.DotNetTestRunner
             ProcessStartInfo.Arguments = arguments;
 
             using Process? ps = await ProcessExecution.Start(ProcessStartInfo);
-            ProcessExecution.FetchOutput(ps);
-            ProcessExecution.FetchError(ps);
-            ExitCode = await ProcessExecution.End(ps);
+            ProcessExecution.FetchOutput(ps!);
+            ProcessExecution.FetchError(ps!);
+            ExitCode = await ProcessExecution.End(ps!);
 
             HandleProcessEnd();
         }

--- a/src/DotNetTestRunner/ProcessExecution.cs
+++ b/src/DotNetTestRunner/ProcessExecution.cs
@@ -22,7 +22,7 @@ public class ProcessExecution : IProcessExecution
     {
         process.OutputDataReceived += (sender, args) =>
         {
-            Log.Verbose(args.Data);
+            Log.Verbose(args.Data!);
             Output += $"\n{args.Data}";
         };
         process.BeginOutputReadLine();
@@ -32,7 +32,7 @@ public class ProcessExecution : IProcessExecution
     {
         process.ErrorDataReceived += (sender, args) =>
         {
-            Log.Error(args.Data);
+            Log.Error(args.Data!);
             Error += $"\n{args.Data}";
         };
         process.BeginErrorReadLine();

--- a/src/Logging/ILogger.cs
+++ b/src/Logging/ILogger.cs
@@ -49,7 +49,7 @@ namespace dotnet.test.rerun.Logging
         /// Logs the progress of an operation, single line with a spinner
         /// </summary>
         /// <param name="msg">initial message to print</param>
-        public void Status(string msg, Action<StatusContext> action = null);
+        public void Status(string msg, Action<StatusContext> action = null!);
 
         /// <summary>
         /// renders a renderable Spectre object (currently we use it for trees)

--- a/src/Logging/Logger.cs
+++ b/src/Logging/Logger.cs
@@ -85,7 +85,7 @@ namespace dotnet.test.rerun.Logging
         /// Logs the progress of an operation, single line with a spinner
         /// </summary>
         /// <param name="msg">initial message to print</param>
-        public void Status(string msg, Action<StatusContext> action = null)
+        public void Status(string msg, Action<StatusContext> action = null!)
         {
             AnsiConsole.Status().Start(msg, ctx =>
             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -22,7 +22,7 @@ var serviceProvider = new ServiceCollection()
 var Log = serviceProvider.GetRequiredService<ILogger>();
 var cmd = serviceProvider.GetService<RerunCommand>();
 
-return await new CommandLineBuilder(cmd)
+await new CommandLineBuilder(cmd)
     .UseDefaults()
     .UseExceptionHandler((exception, context) =>
     {
@@ -37,6 +37,10 @@ return await new CommandLineBuilder(cmd)
         {
             Log.Exception(exception);
         }
+        
+        Environment.ExitCode = 1;
     })
     .Build()
     .InvokeAsync(args);
+
+return Environment.ExitCode;

--- a/src/RerunCommand/RerunCommand.cs
+++ b/src/RerunCommand/RerunCommand.cs
@@ -84,13 +84,18 @@ public class RerunCommand : RootCommand
             }
         }
 
+        if (DotNetTestRunner.GetErrorCode() == ErrorCode.FailedTests)
+        {
+            Environment.ExitCode = 1;
+        }
+
         if (Config.DeleteReportFiles)
         {
             TestResultsAnalyzer.AddLastTrxFile(resultsDirectory);
             DeleteFiles();
         }
     }
-    
+
     private void DeleteFiles()
     {
         foreach (var file in TestResultsAnalyzer.GetReportFiles())

--- a/src/RerunCommand/RerunCommandConfiguration.cs
+++ b/src/RerunCommand/RerunCommandConfiguration.cs
@@ -133,10 +133,10 @@ public class RerunCommandConfiguration
     public void GetValues(InvocationContext context)
     {
         Path = context.ParseResult.GetValueForArgument(PathArgument);
-        Filter = context.ParseResult.GetValueForOption(FilterOption);
-        Settings = context.ParseResult.GetValueForOption(SettingsOption);
-        TrxLogger = context.ParseResult.GetValueForOption(LoggerOption);
-        ResultsDirectory = context.ParseResult.GetValueForOption(ResultsDirectoryOption);
+        Filter = context.ParseResult.GetValueForOption(FilterOption)!;
+        Settings = context.ParseResult.GetValueForOption(SettingsOption)!;
+        TrxLogger = context.ParseResult.GetValueForOption(LoggerOption)!;
+        ResultsDirectory = context.ParseResult.GetValueForOption(ResultsDirectoryOption)!;
         RerunMaxAttempts = context.ParseResult.GetValueForOption(RerunMaxAttemptsOption);
         LogLevel = context.ParseResult.GetValueForOption(LogLevelOption);
         NoBuild = context.ParseResult.FindResultFor(NoBuildOption) is not null;

--- a/src/dotnet-test-rerun.csproj
+++ b/src/dotnet-test-rerun.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression> GPL-3.0-or-later</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>1.3.0-alpha.0</Version>
+    <Version>1.3.0-alpha.1</Version>
     <PackageProjectUrl>https://github.com/joaoopereira/dotnet-test-rerun</PackageProjectUrl>
     <Description>wrapper of dotnet test command that automatic rerun failed tests</Description>
     <RepositoryUrl>https://github.com/joaoopereira/dotnet-test-rerun</RepositoryUrl>

--- a/src/dotnet-test-rerun.csproj
+++ b/src/dotnet-test-rerun.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression> GPL-3.0-or-later</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>1.2.2-alpha.1</Version>
+    <Version>1.3.0-alpha.0</Version>
     <PackageProjectUrl>https://github.com/joaoopereira/dotnet-test-rerun</PackageProjectUrl>
     <Description>wrapper of dotnet test command that automatic rerun failed tests</Description>
     <RepositoryUrl>https://github.com/joaoopereira/dotnet-test-rerun</RepositoryUrl>

--- a/src/dotnet-test-rerun.csproj
+++ b/src/dotnet-test-rerun.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression> GPL-3.0-or-later</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>1.3.0-alpha.1</Version>
+    <Version>1.3.0-alpha.2</Version>
     <PackageProjectUrl>https://github.com/joaoopereira/dotnet-test-rerun</PackageProjectUrl>
     <Description>wrapper of dotnet test command that automatic rerun failed tests</Description>
     <RepositoryUrl>https://github.com/joaoopereira/dotnet-test-rerun</RepositoryUrl>

--- a/src/dotnet-test-rerun.csproj
+++ b/src/dotnet-test-rerun.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression> GPL-3.0-or-later</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>1.2.2-alpha.0</Version>
+    <Version>1.2.2-alpha.1</Version>
     <PackageProjectUrl>https://github.com/joaoopereira/dotnet-test-rerun</PackageProjectUrl>
     <Description>wrapper of dotnet test command that automatic rerun failed tests</Description>
     <RepositoryUrl>https://github.com/joaoopereira/dotnet-test-rerun</RepositoryUrl>

--- a/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
@@ -200,7 +200,7 @@ public class DotNetTestRerunTests
 
         // Assert
         output.Should().NotContain("Passed!");
-        output.Should().Contain("Failed!", Exactly.Times(4));g
+        output.Should().Contain("Failed!", Exactly.Times(4));
         output.Should().Contain("Rerun filter: FullyQualifiedName~FailingXUnitExample.SimpleTest.SimpleFailedNumberCompare",
             Exactly.Thrice());        
         output.Should().Contain("Failed:     2, Passed:     5",

--- a/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
@@ -173,9 +173,6 @@ public class DotNetTestRerunTests
     {
         // Arrange
         Environment.ExitCode = 0;
-
-        // Arrange
-        string folderPath = @"C:\path\to\folder";
         
         Process process = new Process();
         process.StartInfo.FileName = "test-rerun";

--- a/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.Diagnostics;
 using System.IO.Abstractions;
 using dotnet_test_rerun.IntegrationTests.Utilities;
 using dotnet.test.rerun.Analyzers;
@@ -24,28 +25,58 @@ public class DotNetTestRerunTests
     [Fact]
     public async Task DotnetTestRerun_RunXUnitExample_Success()
     {
+        // Arrange
+        Environment.ExitCode = 0;
+
         // Act
         var output = await RunDotNetTestRerunAndCollectOutputMessage("XUnitExample");
 
         // Assert
         output.Should().Contain("Passed!", Exactly.Once());
         output.Should().NotContainAny(new string[] {"Failed!", "Rerun attempt"});
+        Environment.ExitCode.Should().Be(0);
     }
 
     [Fact]
     public async Task DotnetTestRerun_RunMSTestExample_Success()
     {
+        // Arrange
+        Environment.ExitCode = 0;
+
         // Act
         var output = await RunDotNetTestRerunAndCollectOutputMessage("MSTestExample");
 
         // Assert
         output.Should().Contain("Passed!", Exactly.Once());
         output.Should().NotContainAny(new string[] {"Failed!", "Rerun attempt"});
+        Environment.ExitCode.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DotnetTestRerun_RunMSTestExample_RunningProcess_Success()
+    {        
+        // Arrange
+        Environment.ExitCode = 0;
+
+        // Arrange
+        Process process = new Process();
+        process.StartInfo.FileName = "test-rerun";
+        process.StartInfo.Arguments = $"{_dir}\\MSTestExample --rerunMaxAttempts 3 --results-directory {_dir}";
+        
+        // Act
+        process.Start();
+
+        // Assert
+        await process.WaitForExitAsync();
+        process.ExitCode.Should().Be(0);
     }
 
     [Fact]
     public async Task DotnetTestRerun_FailingMSTest_Fails()
     {
+        // Arrange
+        Environment.ExitCode = 0;
+
         // Act
         var output = await RunDotNetTestRerunAndCollectOutputMessage("FailingMSTestExample");
 
@@ -56,17 +87,22 @@ public class DotNetTestRerunTests
             Exactly.Thrice());        
         output.Should().Contain("Failed:     2, Passed:     6",
             Exactly.Once());
+        Environment.ExitCode.Should().Be(1);
     }
 
     [Fact]
     public async Task DotnetTestRerun_RunNUnitExample_Success()
     {
+        // Arrange
+        Environment.ExitCode = 0;
+        
         // Act
         var output = await RunDotNetTestRerunAndCollectOutputMessage("NUnitTestExample");
 
         // Assert
         output.Should().Contain("Passed!", Exactly.Once());
         output.Should().NotContainAny(new string[] {"Failed!", "Rerun attempt"});
+        Environment.ExitCode.Should().Be(0);
     }
 
     [Fact]
@@ -91,8 +127,12 @@ public class DotNetTestRerunTests
     public async Task DotnetTestRerun_FailingXUnit_Fails()
     {
         // Arrange
+        Environment.ExitCode = 0;
+        
+        // Arrange
         var testDir = TestUtilities.GetTmpDirectory();
         TestUtilities.CopyFixture(string.Empty, new DirectoryInfo(testDir));
+        Environment.ExitCode = 0;
         
         // Act
         var output = await RunDotNetTestRerunAndCollectOutputMessage("FailingXUnitExample", dir: testDir);
@@ -104,14 +144,57 @@ public class DotNetTestRerunTests
             Exactly.Thrice());        
         output.Should().Contain("Passed:     4",
             Exactly.Once());
-
         var files = FileSystem.Directory.EnumerateFiles(testDir, "*trx");
         files.Should().HaveCount(4);
+        Environment.ExitCode.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DotnetTestRerun_FailingXUnit_RunningProcess_Fails()
+    {
+        // Arrange
+        Environment.ExitCode = 0;
+
+        // Arrange
+        Process process = new Process();
+        process.StartInfo.FileName = "test-rerun";
+        process.StartInfo.Arguments = $"{_dir}\\FailingXUnitExample --rerunMaxAttempts 3 --results-directory {_dir}";
+        
+        // Act
+        process.Start();
+
+        // Assert
+        await process.WaitForExitAsync();
+        process.ExitCode.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DotnetTestRerun_RunNonExistentXUnitProject_MissingArguments_Fails()
+    {
+        // Arrange
+        Environment.ExitCode = 0;
+
+        // Arrange
+        string folderPath = @"C:\path\to\folder";
+        
+        Process process = new Process();
+        process.StartInfo.FileName = "test-rerun";
+        process.StartInfo.Arguments = $"{_dir}\\XUnitThatDoesNotExist --rerunMaxAttempts 3 --results-directory {_dir}";
+        
+        // Act
+        process.Start();
+
+        // Assert
+        await process.WaitForExitAsync();
+        process.ExitCode.Should().Be(1);
     }
 
     [Fact]
     public async Task DotnetTestRerun_FailingMultipleXUnit_Fails()
     {
+        // Arrange
+        Environment.ExitCode = 0;
+
         // Act
         var output = await RunDotNetTestRerunAndCollectOutputMessage("FailingMultipleXUnitExample");
 
@@ -122,6 +205,7 @@ public class DotNetTestRerunTests
             Exactly.Thrice());        
         output.Should().Contain("Failed:     2, Passed:     5",
             Exactly.Once());
+        Environment.ExitCode.Should().Be(1);
     }
 
     public async Task DotnetTestRerun_FailingXUnit_WithDeleteFiles()

--- a/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
@@ -207,7 +207,8 @@ public class DotNetTestRerunTests
             Exactly.Once());
         Environment.ExitCode.Should().Be(1);
     }
-
+    
+    [Fact]
     public async Task DotnetTestRerun_FailingXUnit_WithDeleteFiles()
     {
         // Arrange

--- a/test/dotnet-test-rerun.UnitTests/DotNetTestRunner/DotNetTestRunnerTests.cs
+++ b/test/dotnet-test-rerun.UnitTests/DotNetTestRunner/DotNetTestRunnerTests.cs
@@ -17,7 +17,7 @@ namespace dotnet_test_rerun.UnitTest.DotNetTestRunner;
 public class DotNetTestRunnerTests
 {
     [Fact]
-    public async Task GetErrorCode_GetDefaultValue()
+    public void GetErrorCode_GetDefaultValue()
     {
         // Arrange
         var logger = new Logger();

--- a/test/dotnet-test-rerun.UnitTests/Logging/StatusContextTests.cs
+++ b/test/dotnet-test-rerun.UnitTests/Logging/StatusContextTests.cs
@@ -13,7 +13,7 @@ public class StatusContextTests
     public void StatusContextTests_WithNullContext_Status_ShouldThrowException()
     {
         // Arrange
-        var statusContext = new StatusContext(null);
+        var statusContext = new StatusContext(null!);
         
         // Act
         var act = () => statusContext.Status("test");

--- a/test/dotnet-test-rerun.UnitTests/RerunCommand/RerunCommandConfigurationTests.cs
+++ b/test/dotnet-test-rerun.UnitTests/RerunCommand/RerunCommandConfigurationTests.cs
@@ -30,8 +30,8 @@ public class RerunCommandConfigurationUnitTests
         //Assert
         var option = Command.Children.FirstOrDefault(x => x is Option opt && opt.HasAlias(optionName)) as Option;
         option.Should().NotBeNull();
-        option.Description.Should().Be(description);
-        option.IsRequired.Should().Be(isRequired);
+        option!.Description.Should().Be(description);
+        option!.IsRequired.Should().Be(isRequired);
     }
 
     [Fact]


### PR DESCRIPTION
![image](https://github.com/joaoopereira/dotnet-test-rerun/assets/93729031/89583294-a54b-493c-867f-fcf8107c93eb)
