### PR TITLE
feat: allow properties to be set (/p:) on execution of dotnet test rerun

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ test-rerun [somepathtodll] [OPTIONS]
 | `--collect` | Enables data collector for the test run. Example: --collect "Code Coverage" or --collect "XPlat Code Coverage"                     |
 | `--mergeCoverageFormat` | Output coverage format. Possible values: Coverage, Cobertura or Xml <br/><br/>Note: requires dotnet coverage tool to be installed. |
 
+
+Note: Sending `/p:` instructions to set property values is also allowed. 
+
 # License
 This tool is licensed under GNU General Public License v3.0. See the [LICENSE](/LICENSE) file for details.
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [versionize](https://github.com/versionize/versionize) for commit guidelines.
 
+<a name="1.4.0-alpha.4"></a>
+## [1.4.0-alpha.4](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.4.0-alpha.4) (2023-8-1)
+
+### Features
+
+* allow properties to be set (/p:) on execution of dotnet test rerun ([113e8d0](https://www.github.com/joaoopereira/dotnet-test-rerun/commit/113e8d0ccacff375ea86833b50fb7c05a73b1efa))
+
 <a name="1.4.0-alpha.3"></a>
 ## [1.4.0-alpha.3](https://www.github.com/joaoopereira/dotnet-test-rerun/releases/tag/v1.4.0-alpha.3) (2023-8-1)
 

--- a/src/DotNetRunner/DotNetTestRunner.cs
+++ b/src/DotNetRunner/DotNetTestRunner.cs
@@ -35,14 +35,7 @@ public class DotNetTestRunner : IDotNetTestRunner
     /// <param name="config">The config.</param>
     /// <param name="resultsDirectory">The results directory.</param>
     public async Task Test(RerunCommandConfiguration config, string resultsDirectory)
-    {
-        string arguments = config.GetTestArgumentList();
-
-        if (string.IsNullOrEmpty(resultsDirectory) is false)
-            arguments = $"{arguments} --results-directory {resultsDirectory}";
-
-        await Run(arguments);
-    }
+        => await Run(config.GetTestArgumentList(resultsDirectory));
 
     public ErrorCode GetErrorCode()
         => ErrorCode;

--- a/src/dotnet-test-rerun.csproj
+++ b/src/dotnet-test-rerun.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression> GPL-3.0-or-later</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>1.4.0-alpha.3</Version>
+    <Version>1.4.0-alpha.4</Version>
     <PackageProjectUrl>https://github.com/joaoopereira/dotnet-test-rerun</PackageProjectUrl>
     <Description>wrapper of dotnet test command that automatic rerun failed tests</Description>
     <RepositoryUrl>https://github.com/joaoopereira/dotnet-test-rerun</RepositoryUrl>

--- a/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
@@ -108,6 +108,21 @@ public class DotNetTestRerunTests
     }
 
     [Fact]
+    public async Task DotnetTestRerun_RunNUnitExample_WithPropertiesActive_Success()
+    {
+        // Arrange
+        Environment.ExitCode = 0;
+        
+        // Act
+        var output = await RunDotNetTestRerunAndCollectOutputMessage("NUnitTestExample", extraArgs: $"/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput={_dir}\\TestResults\\Coverage\\UnitTests-TestResults.opencover.xml");
+
+        // Assert
+        output.Should().Contain("Passed!", Exactly.Once());
+        output.Should().NotContainAny(new string[] {"Failed!", "Rerun attempt"});
+        Environment.ExitCode.Should().Be(0);
+    }
+
+    [Fact]
     public async Task DotnetTestRerun_RunNUnitExample_WithDeleteFiles()
     {
         // Arrange

--- a/test/dotnet-test-rerun.UnitTests/DotNetTestRunner/DotNetTestRunnerTests.cs
+++ b/test/dotnet-test-rerun.UnitTests/DotNetTestRunner/DotNetTestRunnerTests.cs
@@ -78,7 +78,7 @@ public class DotNetTestRunnerTests
         var act = () => dotNetTestRunner.Test(new RerunCommandConfiguration(), "resultsDirectory");
 
         // Assert
-        await act.Should().ThrowAsync<RerunException>().WithMessage("command:\ndotnet test  --results-directory resultsDirectory");
+        await act.Should().ThrowAsync<RerunException>().WithMessage("command:\ndotnet test  --results-directory \"resultsDirectory\"");
         dotNetTestRunner.GetErrorCode().Should().Be(ErrorCode.Error);
     }
     

--- a/test/dotnet-test-rerun.UnitTests/RerunCommand/RerunCommandConfigurationTests.cs
+++ b/test/dotnet-test-rerun.UnitTests/RerunCommand/RerunCommandConfigurationTests.cs
@@ -91,10 +91,10 @@ public class RerunCommandConfigurationUnitTests
         _configuration.GetValues(context);
 
         //Act
-        var args = _configuration.GetTestArgumentList();
+        var args = _configuration.GetTestArgumentList("results-directory");
 
         //Assert
-        args.Should().Be("test path --filter \"filter\" --settings \"settings\" --logger \"logger\"");
+        args.Should().Be("test path --filter \"filter\" --settings \"settings\" --logger \"logger\" --results-directory \"results-directory\"");
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class RerunCommandConfigurationUnitTests
         _configuration.Set(Command); 
 
         //Act
-        var args = _configuration.GetTestArgumentList();
+        var args = _configuration.GetTestArgumentList("");
 
         //Assert
         args.Should().Be("test ");


### PR DESCRIPTION

![image](https://github.com/joaoopereira/dotnet-test-rerun/assets/93729031/b6fc3a21-45aa-4e35-b2a1-4d73c44da2bc)


#50