### PR TITLE
fix: on retry add original filter as well as failed tests

### DIFF
--- a/src/RerunCommand/RerunCommand.cs
+++ b/src/RerunCommand/RerunCommand.cs
@@ -67,8 +67,9 @@ public class RerunCommand : RootCommand
                     }
 
                     Log.Information($"Rerun attempt {attempt}/{Config.RerunMaxAttempts}");
-                    Log.Warning($"Found Failed tests. Rerun filter: {testsToRerun}");
-                    Config.Filter = testsToRerun;
+                    Log.Warning($"Found Failed tests: {testsToRerun}");
+                    Config.Filter = Config.AppendFailedTests(testsToRerun);
+                    Log.Warning($"Rerun filter: {Config.Filter}");
                     startOfDotnetRun = DateTime.Now;
                     await DotNetTestRunner.Test(Config, resultsDirectory.FullName);
                     attempt++;

--- a/src/RerunCommand/RerunCommandConfiguration.cs
+++ b/src/RerunCommand/RerunCommandConfiguration.cs
@@ -154,6 +154,8 @@ public class RerunCommandConfiguration
 
     #endregion Options
 
+    private string OriginalFilter;
+    
     public void Set(Command cmd)
     {
         cmd.Add(PathArgument);
@@ -193,6 +195,9 @@ public class RerunCommandConfiguration
         Collector = context.ParseResult.GetValueForOption(CollectorOption)!;
         MergeCoverageFormat = context.ParseResult.GetValueForOption(MergeCoverageFormatOption);
         pArguments = FetchPArgumentsFromParse(context.ParseResult);
+        
+        //Store Original Values
+        OriginalFilter = Filter;
     }
 
     public string GetTestArgumentList(string resultsDirectory)
@@ -226,6 +231,11 @@ public class RerunCommandConfiguration
             ? $" {option.Aliases.First()}"
             : string.Empty;
 
+    public string AppendFailedTests(string failedTests)
+        => string.IsNullOrWhiteSpace(OriginalFilter) ? 
+            failedTests : 
+            string.Concat("(", OriginalFilter, ")", "&(", failedTests, ")");
+    
     private string GetMergeExtension()
         => MergeCoverageFormat switch
         {

--- a/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
@@ -244,6 +244,26 @@ public class DotNetTestRerunTests
             Exactly.Once());
         Environment.ExitCode.Should().Be(0);
     }
+
+    [Fact]
+    public async Task DotnetTestRerun_FailingNUnit_PassOnSecond_WithCategory()
+    {
+        // Arrange
+        Environment.ExitCode = 0;
+
+        // Act
+        var output = await RunDotNetTestRerunAndCollectOutputMessage("NUnitTestPassOnSecondRunExampleWithCategory",
+            "--filter TestCategory=FirstCategory|TestCategory=SecondCategory");
+
+        // Assert
+        output.Should().Contain("Passed!");
+        output.Should().Contain("Failed!", Exactly.Times(1));
+        output.Should().Contain("Rerun filter: (TestCategory=FirstCategory|TestCategory=SecondCategory)&(FullyQualifiedName~SecondSimpleNumberCompare)",
+            Exactly.Once());        
+        output.Should().Contain("Failed:     1, Passed:     1",
+            Exactly.Once());
+        Environment.ExitCode.Should().Be(0);
+    }
     
     [Fact]
     public async Task DotnetTestRerun_FailingXUnit_WithDeleteFiles()

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/NUnitTestPassOnSecondRunExampleWithCategory/NUnitTestPassOnSecondRunExampleWithCategory.csproj
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/NUnitTestPassOnSecondRunExampleWithCategory/NUnitTestPassOnSecondRunExampleWithCategory.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    </ItemGroup>
+
+</Project>

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/NUnitTestPassOnSecondRunExampleWithCategory/SimpleTest.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/NUnitTestPassOnSecondRunExampleWithCategory/SimpleTest.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+
+namespace NUnitTestExample;
+
+public class Tests
+{
+    private int number = 2;
+    
+    [Test, Order(1)]
+    [Category("FirstCategory")]
+    public void SimpleNumberCompare()
+    {
+        number = 3;
+        Assert.AreEqual(3, number);
+    }
+    
+    [Test, Order(2)]
+    [Category("SecondCategory")]
+    public void SecondSimpleNumberCompare()
+    {
+        Assert.AreEqual(2, number);
+    }
+}

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/NUnitTestPassOnSecondRunExampleWithCategory/Usings.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/NUnitTestPassOnSecondRunExampleWithCategory/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;


### PR DESCRIPTION
![image](https://github.com/joaoopereira/dotnet-test-rerun/assets/93729031/e5acf27d-4bed-42ee-bc81-4d9a647e3b39)

#80