### PR TITLE
fix: handle special characters in test filter

### DIFF
--- a/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
@@ -169,6 +169,22 @@ public class DotNetTestRerunTests
         var files = FileSystem.Directory.EnumerateFiles(testDir, "*trx");
         files.Should().HaveCount(4);
         Environment.ExitCode.Should().Be(1);
+    }    
+    
+    [Fact]
+    public async Task DotnetTestRerun_FailingXUnit_FailsInAllRetries()
+    {
+        // Arrange
+        Environment.ExitCode = 0;
+
+        // Act
+        var output = await RunDotNetTestRerunAndCollectOutputMessage("XUnitExampleFailInAllRetries");
+
+        // Assert
+        output.Should().Contain("Failed!", Exactly.Times(4));
+        output.Should().Contain("Failed:     2, Passed:     0", Exactly.Times(4));
+        Environment.ExitCode.Should().Be(1);
+        IsThereACoverageFile().Should().BeFalse();
     }
 
     [Fact]

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetries/SimpleTest.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetries/SimpleTest.cs
@@ -1,0 +1,12 @@
+namespace XUnitExample;
+
+public class SimpleTest
+{
+    [Theory]
+    [InlineData("Test 1")]
+    [InlineData("Test (2")]
+    public void Test1(string _)
+    {
+        Assert.False(true);
+    }
+}

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetries/Usings.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetries/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetries/XUnitExampleFailInAllRetries.csproj
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetries/XUnitExampleFailInAllRetries.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Context
Special characters in test arguments generates invalid TestCaseFilter

## Description
When special characters are used in test filter rerun fails

## Changes in the codebase
Added some escape characters when building test filter

## Associated Issues
#176 