### PR TITLE
Fix retry logic when using Theory.DisplayName

### DIFF
--- a/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/DotNetTestRerunTests.cs
@@ -188,6 +188,22 @@ public class DotNetTestRerunTests
     }
 
     [Fact]
+    public async Task DotnetTestRerun_FailingXUnit_FailsInAllRetriesWithDisplayName()
+    {
+        // Arrange
+        Environment.ExitCode = 0;
+
+        // Act
+        var output = await RunDotNetTestRerunAndCollectOutputMessage("XUnitExampleFailInAllRetriesWithDisplayName");
+
+        // Assert
+        output.Should().Contain("Failed!", Exactly.Times(4));
+        output.Should().Contain("Failed:     2, Passed:     0", Exactly.Times(4));
+        Environment.ExitCode.Should().Be(1);
+        IsThereACoverageFile().Should().BeFalse();
+    }
+
+    [Fact]
     public async Task DotnetTestRerun_FailingXUnit_PassOnSecond()
     {
         // Arrange

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetriesWithDisplayName/SimpleTest.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetriesWithDisplayName/SimpleTest.cs
@@ -1,0 +1,12 @@
+namespace XUnitExample;
+
+public class SimpleTest
+{
+    [Theory(DisplayName = "My overriden test name")]
+    [InlineData("Test 1")]
+    [InlineData("Test (2")]
+    public void Test1(string _)
+    {
+        Assert.False(true);
+    }
+}

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetriesWithDisplayName/Usings.cs
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetriesWithDisplayName/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetriesWithDisplayName/XUnitExampleFailInAllRetriesWithDisplayName.csproj
+++ b/test/dotnet-test-rerun.IntegrationTests/Fixtures/XUnitExampleFailInAllRetriesWithDisplayName/XUnitExampleFailInAllRetriesWithDisplayName.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Context
Hello. Thank you for maintaining this project. It has been very helpful!

When using xUnit's `Theory(DisplayName = "...")`, failed tests are not retried because the analyzer builds filters from the `DisplayName` instead of the actual method name.

## Description
The `TestResultsAnalyzer` uses `UnitTestResult.TestName` (the `DisplayName`) to build rerun filters.
`dotnet test` only recognizes real method names and ignores aliases, so retries fail.

So I fixed it:
- Use `TestDefinitions.UnitTest.TestMethod.Name` for the `FullyQualifiedName` filter.
- Refactored filter-building logic a little to separate responsibilities and improve maintainability.

## Changes in the codebase
1. Added demonstration test to reproduce the retry issue (for review; can be removed before merging).
2. Split `FullyQualifiedName` and `DisplayName` filter builders into separate methods.
3. Updated `FullyQualifiedName` filter to use `TestMethod.Name` instead of `TestResult.TestName`.
4. Removed `StringBuilder` in favor of simpler concatenation for readability. For such number of concatenations it has not so much sense, but it makes code a little harder to read.

## Associated Issues
No issue associated